### PR TITLE
feat(Auth): create Register screen

### DIFF
--- a/.chglog/CHANGELOG.tpl.md
+++ b/.chglog/CHANGELOG.tpl.md
@@ -1,0 +1,56 @@
+{{ if .Versions -}}
+<a name="unreleased"></a>
+## [Unreleased]
+
+{{ if .Unreleased.CommitGroups -}}
+{{ range .Unreleased.CommitGroups -}}
+### {{ .Title }}
+{{ range .Commits -}}
+- {{ if .Scope }}**{{ .Scope }}:** {{ end }}{{ .Subject }}
+{{ end }}
+{{ end -}}
+{{ end -}}
+{{ end -}}
+
+{{ range .Versions }}
+<a name="{{ .Tag.Name }}"></a>
+## {{ if .Tag.Previous }}[{{ .Tag.Name }}]{{ else }}{{ .Tag.Name }}{{ end }} - {{ datetime "2006-01-02" .Tag.Date }}
+{{ range .CommitGroups -}}
+### {{ .Title }}
+{{ range .Commits -}}
+- {{ if .Scope }}**{{ .Scope }}:** {{ end }}{{ .Subject }}
+{{ end }}
+{{ end -}}
+
+{{- if .RevertCommits -}}
+### Reverts
+{{ range .RevertCommits -}}
+- {{ .Revert.Header }}
+{{ end }}
+{{ end -}}
+
+{{- if .MergeCommits -}}
+### Pull Requests
+{{ range .MergeCommits -}}
+- {{ .Header }}
+{{ end }}
+{{ end -}}
+
+{{- if .NoteGroups -}}
+{{ range .NoteGroups -}}
+### {{ .Title }}
+{{ range .Notes }}
+{{ .Body }}
+{{ end }}
+{{ end -}}
+{{ end -}}
+{{ end -}}
+
+{{- if .Versions }}
+[Unreleased]: {{ .Info.RepositoryURL }}/compare/{{ $latest := index .Versions 0 }}{{ $latest.Tag.Name }}...HEAD
+{{ range .Versions -}}
+{{ if .Tag.Previous -}}
+[{{ .Tag.Name }}]: {{ $.Info.RepositoryURL }}/compare/{{ .Tag.Previous.Name }}...{{ .Tag.Name }}
+{{ end -}}
+{{ end -}}
+{{ end -}}

--- a/.chglog/config.yml
+++ b/.chglog/config.yml
@@ -1,0 +1,28 @@
+style: github
+template: CHANGELOG.tpl.md
+info:
+  title: CHANGELOG
+  repository_url: https://github.com/pereyrarg11/Navigation
+options:
+  commits:
+    # filters:
+    #   Type:
+    #     - feat
+    #     - fix
+    #     - perf
+    #     - refactor
+  commit_groups:
+    # title_maps:
+    #   feat: Features
+    #   fix: Bug Fixes
+    #   perf: Performance Improvements
+    #   refactor: Code Refactoring
+  header:
+    pattern: "^(\\w*)(?:\\(([\\w\\$\\.\\-\\*\\s]*)\\))?\\:\\s(.*)$"
+    pattern_maps:
+      - Type
+      - Scope
+      - Subject
+  notes:
+    keywords:
+      - BREAKING CHANGE

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @pereyrarg11

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,42 @@
+### Description
+
+Brief description of the changes introduced by this pull request.
+
+### Context
+
+Why were these changes made? Is there any related issue or linked task?
+
+### Changes
+
+List all changes done
+
+### Type of Changes
+
+Check with an 'x' the type of changes made:
+
+- [ ] New Feature
+- [ ] Bug Fix
+- [ ] Dependency upgrade
+- [ ] Refactor
+- [ ] Performance Improvement
+- [ ] Style Changes (formatting, spacing, etc.)
+- [ ] Documentation
+- [ ] Other (specify)
+
+### Code Quality Checks
+
+- [ ] All app-flavors and build-variants have been built successfully.
+- [ ] Coding style of the project has been followed.
+- [ ] Documentation has been updated, if necessary.
+
+### Screenshots
+
+Attach screenshots or images that help understand and visualize the changes made.
+
+### Additional Notes
+
+Additional information you consider relevant for code review.
+
+### Related Links
+
+Include links to tasks, issues, or related documentation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+<a name="unreleased"></a>
+## [Unreleased]
+
+### Feat
+- **Auth:** create Register screen
+
+
+<a name="v0.1.0"></a>
+## v0.1.0 - 2025-07-30
+### Chore
+- **Core:** improve AppTextField
+- **Core:** add UI tools
+- **Core:** typography, colors and theme for Design System
+- **Core:** create components for Design System
+- **MainActivity:** add bottom navigation bar
+- **Project:** change icon launcher
+- **Project:** create project
+
+
+[Unreleased]: https://github.com/pereyrarg11/Navigation/compare/v0.1.0...HEAD

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,12 +1,16 @@
+import com.android.build.gradle.internal.cxx.configure.gradleLocalProperties
+
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
+    alias(libs.plugins.kotlin.serialization)
 }
 
 android {
     namespace = "com.pereyrarg11.navigation"
     compileSdk = 35
+    android.buildFeatures.buildConfig = true
 
     defaultConfig {
         applicationId = "com.pereyrarg11.navigation"
@@ -16,6 +20,11 @@ android {
         versionName = "1.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        buildConfigField(
+            type = "String",
+            name = "AUTH_URL",
+            value = "\"${gradleLocalProperties(rootDir, providers).getProperty("AUTH_URL")}\""
+        )
     }
 
     buildTypes {
@@ -49,6 +58,14 @@ dependencies {
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
+    implementation(libs.koin.androidx.compose)
+    implementation(libs.koin.androidx.compose.navigation)
+    implementation(libs.ktor.client.auth)
+    implementation(libs.ktor.client.cio)
+    implementation(libs.ktor.client.content.negotiation)
+    implementation(libs.ktor.client.core)
+    implementation(libs.ktor.client.logging)
+    implementation(libs.ktor.serialization.kotlinx.json)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,7 +2,10 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <application
+        android:name=".NavigationApp"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
@@ -15,7 +18,6 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
-            android:label="@string/app_name"
             android:theme="@style/Theme.Navigation">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/com/pereyrarg11/navigation/MainActivity.kt
+++ b/app/src/main/java/com/pereyrarg11/navigation/MainActivity.kt
@@ -27,8 +27,10 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import com.pereyrarg11.navigation.auth.presentation.register.RegisterScreen
 import com.pereyrarg11.navigation.core.presentation.designsystem.AppTheme
 import com.pereyrarg11.navigation.presentation.data.BottomNavigationItem
+import org.koin.androidx.compose.KoinAndroidContext
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -60,52 +62,54 @@ class MainActivity : ComponentActivity() {
                 mutableIntStateOf(0)
             }
             AppTheme {
-                Scaffold(
-                    modifier = Modifier.fillMaxSize(),
-                    bottomBar = {
-                        NavigationBar {
-                            items.forEachIndexed { index, item ->
-                                NavigationBarItem(
-                                    selected = index == selectedItemIndex,
-                                    onClick = {
-                                        selectedItemIndex = index
-                                        // TODO: use navController to navigate
-                                    },
-                                    label = {
-                                        Text(text = item.title)
-                                    },
-                                    alwaysShowLabel = false,
-                                    icon = {
-                                        BadgedBox(
-                                            badge = {
-                                                if (item.badgeCount != null) {
-                                                    Badge {
-                                                        Text(text = item.badgeCount.toString())
+                KoinAndroidContext {
+                    Scaffold(
+                        modifier = Modifier.fillMaxSize(),
+                        bottomBar = {
+                            NavigationBar {
+                                items.forEachIndexed { index, item ->
+                                    NavigationBarItem(
+                                        selected = index == selectedItemIndex,
+                                        onClick = {
+                                            selectedItemIndex = index
+                                            // TODO: use navController to navigate
+                                        },
+                                        label = {
+                                            Text(text = item.title)
+                                        },
+                                        alwaysShowLabel = false,
+                                        icon = {
+                                            BadgedBox(
+                                                badge = {
+                                                    if (item.badgeCount != null) {
+                                                        Badge {
+                                                            Text(text = item.badgeCount.toString())
+                                                        }
+                                                    } else if (item.hasNews) {
+                                                        Badge()
                                                     }
-                                                } else if (item.hasNews) {
-                                                    Badge()
-                                                }
-                                            },
-                                        ) {
-                                            Icon(
-                                                imageVector = if (index == selectedItemIndex) {
-                                                    item.selectedIcon
-                                                } else {
-                                                    item.unselectedIcon
                                                 },
-                                                contentDescription = item.title,
-                                            )
+                                            ) {
+                                                Icon(
+                                                    imageVector = if (index == selectedItemIndex) {
+                                                        item.selectedIcon
+                                                    } else {
+                                                        item.unselectedIcon
+                                                    },
+                                                    contentDescription = item.title,
+                                                )
+                                            }
                                         }
-                                    }
-                                )
+                                    )
+                                }
                             }
                         }
+                    ) { innerPadding ->
+                        RegisterScreen(
+                            onSuccessfulRegistration = {},
+                            modifier = Modifier.padding(innerPadding)
+                        )
                     }
-                ) { innerPadding ->
-                    Greeting(
-                        name = "Android",
-                        modifier = Modifier.padding(innerPadding)
-                    )
                 }
             }
         }

--- a/app/src/main/java/com/pereyrarg11/navigation/NavigationApp.kt
+++ b/app/src/main/java/com/pereyrarg11/navigation/NavigationApp.kt
@@ -1,0 +1,26 @@
+package com.pereyrarg11.navigation
+
+import android.app.Application
+import com.pereyrarg11.navigation.auth.data.di.authDataModule
+import com.pereyrarg11.navigation.auth.presentation.di.authPresentationModule
+import com.pereyrarg11.navigation.core.data.di.coreDataModule
+import com.pereyrarg11.navigation.di.appModule
+import org.koin.android.ext.koin.androidContext
+import org.koin.android.ext.koin.androidLogger
+import org.koin.core.context.startKoin
+
+class NavigationApp : Application() {
+    override fun onCreate() {
+        super.onCreate()
+        startKoin {
+            androidContext(this@NavigationApp)
+            androidLogger()
+            modules(
+                appModule,
+                coreDataModule,
+                authDataModule,
+                authPresentationModule,
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/pereyrarg11/navigation/auth/data/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/pereyrarg11/navigation/auth/data/AuthRepositoryImpl.kt
@@ -1,0 +1,45 @@
+package com.pereyrarg11.navigation.auth.data
+
+import com.pereyrarg11.navigation.auth.data.register.RegisterUserRequest
+import com.pereyrarg11.navigation.auth.data.register.UserDto
+import com.pereyrarg11.navigation.auth.data.register.toUser
+import com.pereyrarg11.navigation.auth.domain.AuthRepository
+import com.pereyrarg11.navigation.auth.domain.register.User
+import com.pereyrarg11.navigation.core.data.networking.post
+import com.pereyrarg11.navigation.core.domain.util.AppResult
+import com.pereyrarg11.navigation.core.domain.util.DataError
+import com.pereyrarg11.navigation.core.domain.util.map
+import io.ktor.client.HttpClient
+
+class AuthRepositoryImpl(
+    private val httpClient: HttpClient,
+) : AuthRepository {
+
+    override suspend fun registerUser(
+        name: String,
+        lastName: String,
+        phoneNumber: String,
+        email: String,
+    ): AppResult<User, DataError.Network> {
+        val result = httpClient.post<RegisterUserRequest, UserDto>(
+            route = "/user",
+            body = RegisterUserRequest(
+                name = name,
+                lastName = lastName,
+                phone = phoneNumber,
+                email = email
+            )
+        )
+
+        // handle custom errors here
+        if (result is AppResult.Success && result.data.errorCode == ERROR_CODE_DUPLICATION) {
+            return AppResult.Error(DataError.Network.CONFLICT)
+        }
+
+        return result.map { it.toUser() }
+    }
+
+    companion object {
+        private const val ERROR_CODE_DUPLICATION = 211
+    }
+}

--- a/app/src/main/java/com/pereyrarg11/navigation/auth/data/di/AuthDataModule.kt
+++ b/app/src/main/java/com/pereyrarg11/navigation/auth/data/di/AuthDataModule.kt
@@ -1,0 +1,35 @@
+package com.pereyrarg11.navigation.auth.data.di
+
+import com.pereyrarg11.navigation.auth.data.AuthRepositoryImpl
+import com.pereyrarg11.navigation.auth.data.register.EmailPatternValidator
+import com.pereyrarg11.navigation.auth.data.register.NamePatternValidator
+import com.pereyrarg11.navigation.auth.domain.AuthRepository
+import com.pereyrarg11.navigation.auth.domain.register.PatternValidator
+import com.pereyrarg11.navigation.auth.domain.register.ValidateEmailUseCase
+import com.pereyrarg11.navigation.auth.domain.register.ValidateLastNameUseCase
+import com.pereyrarg11.navigation.auth.domain.register.ValidateNameUseCase
+import com.pereyrarg11.navigation.auth.domain.register.ValidatePhoneNumberUseCase
+import org.koin.core.module.dsl.singleOf
+import org.koin.core.qualifier.named
+import org.koin.dsl.bind
+import org.koin.dsl.module
+
+val authDataModule = module {
+    single<PatternValidator>(named("EmailPattern")) {
+        EmailPatternValidator
+    }
+    single<PatternValidator>(named("ProperNamePattern")) {
+        NamePatternValidator
+    }
+    single {
+        ValidateEmailUseCase(get(named("EmailPattern")))
+    }
+    single {
+        ValidateNameUseCase(get(named("ProperNamePattern")))
+    }
+    single {
+        ValidateLastNameUseCase(get(named("ProperNamePattern")))
+    }
+    singleOf(::ValidatePhoneNumberUseCase)
+    singleOf(::AuthRepositoryImpl).bind<AuthRepository>()
+}

--- a/app/src/main/java/com/pereyrarg11/navigation/auth/data/register/EmailPatternValidator.kt
+++ b/app/src/main/java/com/pereyrarg11/navigation/auth/data/register/EmailPatternValidator.kt
@@ -1,0 +1,10 @@
+package com.pereyrarg11.navigation.auth.data.register
+
+import android.util.Patterns
+import com.pereyrarg11.navigation.auth.domain.register.PatternValidator
+
+object EmailPatternValidator : PatternValidator {
+    override fun matches(value: String): Boolean {
+        return Patterns.EMAIL_ADDRESS.matcher(value).matches()
+    }
+}

--- a/app/src/main/java/com/pereyrarg11/navigation/auth/data/register/NamePatternValidator.kt
+++ b/app/src/main/java/com/pereyrarg11/navigation/auth/data/register/NamePatternValidator.kt
@@ -1,0 +1,11 @@
+package com.pereyrarg11.navigation.auth.data.register
+
+import com.pereyrarg11.navigation.auth.domain.register.PatternValidator
+
+object NamePatternValidator : PatternValidator {
+    override fun matches(value: String): Boolean {
+        val regexPattern = "\\b([A-ZÀ-ÿ][a-z. ]+ *)+"
+        val regex = Regex(regexPattern)
+        return regex.matches(value)
+    }
+}

--- a/app/src/main/java/com/pereyrarg11/navigation/auth/data/register/RegisterUserRequest.kt
+++ b/app/src/main/java/com/pereyrarg11/navigation/auth/data/register/RegisterUserRequest.kt
@@ -1,0 +1,17 @@
+package com.pereyrarg11.navigation.auth.data.register
+
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class RegisterUserRequest(
+    @SerialName("name")
+    val name: String,
+    @SerialName("last_name")
+    val lastName: String,
+    @SerialName("phone")
+    val phone: String,
+    @SerialName("email")
+    val email: String,
+)

--- a/app/src/main/java/com/pereyrarg11/navigation/auth/data/register/UserDto.kt
+++ b/app/src/main/java/com/pereyrarg11/navigation/auth/data/register/UserDto.kt
@@ -1,0 +1,31 @@
+package com.pereyrarg11.navigation.auth.data.register
+
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class UserDto(
+    @SerialName("email")
+    val email: String? = null,
+    @SerialName("full_name")
+    val fullName: String? = null,
+    @SerialName("last_name")
+    val lastName: String? = null,
+    @SerialName("media_path")
+    val mediaPath: String? = null,
+    @SerialName("name")
+    val name: String? = null,
+    @SerialName("phone")
+    val phone: String? = null,
+    @SerialName("phone_verification")
+    val phoneVerification: Boolean? = null,
+    @SerialName("status")
+    val status: Int? = null,
+    @SerialName("uuid")
+    val uuid: String? = null,
+    @SerialName("code")
+    val errorCode: Int? = null,
+    @SerialName("message")
+    val errorMessage: String? = null,
+)

--- a/app/src/main/java/com/pereyrarg11/navigation/auth/data/register/UserMapper.kt
+++ b/app/src/main/java/com/pereyrarg11/navigation/auth/data/register/UserMapper.kt
@@ -1,0 +1,14 @@
+package com.pereyrarg11.navigation.auth.data.register
+
+import com.pereyrarg11.navigation.auth.domain.register.User
+
+fun UserDto.toUser(): User {
+    return User(
+        name = name.orEmpty(),
+        lastName = lastName.orEmpty(),
+        email = email.orEmpty(),
+        phone = phone.orEmpty(),
+        avatarUrl = mediaPath.orEmpty(),
+        uuid = uuid.orEmpty(),
+    )
+}

--- a/app/src/main/java/com/pereyrarg11/navigation/auth/domain/AuthRepository.kt
+++ b/app/src/main/java/com/pereyrarg11/navigation/auth/domain/AuthRepository.kt
@@ -1,0 +1,14 @@
+package com.pereyrarg11.navigation.auth.domain
+
+import com.pereyrarg11.navigation.auth.domain.register.User
+import com.pereyrarg11.navigation.core.domain.util.AppResult
+import com.pereyrarg11.navigation.core.domain.util.DataError
+
+interface AuthRepository {
+    suspend fun registerUser(
+        name: String,
+        lastName: String,
+        phoneNumber: String,
+        email: String,
+    ): AppResult<User, DataError.Network>
+}

--- a/app/src/main/java/com/pereyrarg11/navigation/auth/domain/register/PatternValidator.kt
+++ b/app/src/main/java/com/pereyrarg11/navigation/auth/domain/register/PatternValidator.kt
@@ -1,0 +1,5 @@
+package com.pereyrarg11.navigation.auth.domain.register
+
+interface PatternValidator {
+    fun matches(value: String): Boolean
+}

--- a/app/src/main/java/com/pereyrarg11/navigation/auth/domain/register/RegisterError.kt
+++ b/app/src/main/java/com/pereyrarg11/navigation/auth/domain/register/RegisterError.kt
@@ -1,0 +1,29 @@
+package com.pereyrarg11.navigation.auth.domain.register
+
+import com.pereyrarg11.navigation.core.domain.util.AppError
+
+sealed interface RegisterError : AppError {
+    enum class PhoneNumber : RegisterError {
+        EMPTY,
+        LENGTH,
+        DIGITS
+    }
+
+    enum class Email : RegisterError {
+        EMPTY,
+        PATTERN,
+        TOO_LONG,
+    }
+
+    enum class Name : RegisterError {
+        EMPTY,
+        PATTERN,
+        TOO_LONG
+    }
+
+    enum class LastName : RegisterError {
+        EMPTY,
+        PATTERN,
+        TOO_LONG
+    }
+}

--- a/app/src/main/java/com/pereyrarg11/navigation/auth/domain/register/User.kt
+++ b/app/src/main/java/com/pereyrarg11/navigation/auth/domain/register/User.kt
@@ -1,0 +1,11 @@
+package com.pereyrarg11.navigation.auth.domain.register
+
+
+data class User(
+    val name: String = "",
+    val lastName: String = "",
+    val email: String = "",
+    val phone: String = "",
+    val avatarUrl: String = "",
+    val uuid: String = "",
+)

--- a/app/src/main/java/com/pereyrarg11/navigation/auth/domain/register/ValidateEmailUseCase.kt
+++ b/app/src/main/java/com/pereyrarg11/navigation/auth/domain/register/ValidateEmailUseCase.kt
@@ -1,0 +1,26 @@
+package com.pereyrarg11.navigation.auth.domain.register
+
+class ValidateEmailUseCase(
+    private val emailPatternValidator: PatternValidator,
+) {
+    operator fun invoke(email: String): RegisterError.Email? {
+        if (email.isEmpty()) {
+            return RegisterError.Email.EMPTY
+        }
+
+        val isValidPattern = emailPatternValidator.matches(email)
+        if (!isValidPattern) {
+            return RegisterError.Email.PATTERN
+        }
+
+        if (email.length > EMAIL_MAX_LENGTH) {
+            return RegisterError.Email.TOO_LONG
+        }
+
+        return null
+    }
+
+    companion object {
+        const val EMAIL_MAX_LENGTH = 50
+    }
+}

--- a/app/src/main/java/com/pereyrarg11/navigation/auth/domain/register/ValidateLastNameUseCase.kt
+++ b/app/src/main/java/com/pereyrarg11/navigation/auth/domain/register/ValidateLastNameUseCase.kt
@@ -1,0 +1,26 @@
+package com.pereyrarg11.navigation.auth.domain.register
+
+class ValidateLastNameUseCase(
+    private val lastNamePatternValidator: PatternValidator,
+) {
+    operator fun invoke(lastName: String): RegisterError.LastName? {
+        if (lastName.isEmpty()) {
+            return RegisterError.LastName.EMPTY
+        }
+
+        val isValidPattern = lastNamePatternValidator.matches(lastName)
+        if (!isValidPattern) {
+            return RegisterError.LastName.PATTERN
+        }
+
+        if (lastName.length > LAST_NAME_MAX_LENGTH) {
+            return RegisterError.LastName.TOO_LONG
+        }
+
+        return null
+    }
+
+    companion object {
+        const val LAST_NAME_MAX_LENGTH = 25
+    }
+}

--- a/app/src/main/java/com/pereyrarg11/navigation/auth/domain/register/ValidateNameUseCase.kt
+++ b/app/src/main/java/com/pereyrarg11/navigation/auth/domain/register/ValidateNameUseCase.kt
@@ -1,0 +1,26 @@
+package com.pereyrarg11.navigation.auth.domain.register
+
+class ValidateNameUseCase(
+    private val namePatternValidator: PatternValidator,
+) {
+    operator fun invoke(name: String): RegisterError.Name? {
+        if (name.isEmpty()) {
+            return RegisterError.Name.EMPTY
+        }
+
+        val isValidPattern = namePatternValidator.matches(name)
+        if (!isValidPattern) {
+            return RegisterError.Name.PATTERN
+        }
+
+        if (name.length > NAME_MAX_LENGTH) {
+            return RegisterError.Name.TOO_LONG
+        }
+
+        return null
+    }
+
+    companion object {
+        const val NAME_MAX_LENGTH = 25
+    }
+}

--- a/app/src/main/java/com/pereyrarg11/navigation/auth/domain/register/ValidatePhoneNumberUseCase.kt
+++ b/app/src/main/java/com/pereyrarg11/navigation/auth/domain/register/ValidatePhoneNumberUseCase.kt
@@ -1,0 +1,24 @@
+package com.pereyrarg11.navigation.auth.domain.register
+
+class ValidatePhoneNumberUseCase {
+    operator fun invoke(phoneNumber: String): RegisterError.PhoneNumber? {
+        if (phoneNumber.isEmpty()) {
+            return RegisterError.PhoneNumber.EMPTY
+        }
+
+        if (phoneNumber.length != PHONE_NUMBER_LENGTH) {
+            return RegisterError.PhoneNumber.LENGTH
+        }
+
+        val hasNoDigit = phoneNumber.any { !it.isDigit() }
+        if (hasNoDigit) {
+            return RegisterError.PhoneNumber.DIGITS
+        }
+
+        return null
+    }
+
+    companion object {
+        const val PHONE_NUMBER_LENGTH = 10
+    }
+}

--- a/app/src/main/java/com/pereyrarg11/navigation/auth/presentation/di/AuthPresentationModule.kt
+++ b/app/src/main/java/com/pereyrarg11/navigation/auth/presentation/di/AuthPresentationModule.kt
@@ -1,0 +1,9 @@
+package com.pereyrarg11.navigation.auth.presentation.di
+
+import com.pereyrarg11.navigation.auth.presentation.register.RegisterViewModel
+import org.koin.core.module.dsl.viewModelOf
+import org.koin.dsl.module
+
+val authPresentationModule = module {
+    viewModelOf(::RegisterViewModel)
+}

--- a/app/src/main/java/com/pereyrarg11/navigation/auth/presentation/register/RegisterAction.kt
+++ b/app/src/main/java/com/pereyrarg11/navigation/auth/presentation/register/RegisterAction.kt
@@ -1,0 +1,6 @@
+package com.pereyrarg11.navigation.auth.presentation.register
+
+sealed interface RegisterAction {
+    data object OnClickSubmit : RegisterAction
+    data object OnDismissError : RegisterAction
+}

--- a/app/src/main/java/com/pereyrarg11/navigation/auth/presentation/register/RegisterErrorToText.kt
+++ b/app/src/main/java/com/pereyrarg11/navigation/auth/presentation/register/RegisterErrorToText.kt
@@ -1,0 +1,41 @@
+package com.pereyrarg11.navigation.auth.presentation.register
+
+import com.pereyrarg11.navigation.R
+import com.pereyrarg11.navigation.auth.domain.register.RegisterError
+import com.pereyrarg11.navigation.auth.domain.register.ValidateEmailUseCase
+import com.pereyrarg11.navigation.auth.domain.register.ValidateLastNameUseCase
+import com.pereyrarg11.navigation.auth.domain.register.ValidateNameUseCase
+import com.pereyrarg11.navigation.auth.domain.register.ValidatePhoneNumberUseCase
+import com.pereyrarg11.navigation.core.presentation.tools.UiText
+
+fun RegisterError.toUiText(): UiText {
+    return when (this) {
+        RegisterError.Email.EMPTY -> UiText.StringResource(R.string.auth_error_email_empty)
+        RegisterError.Email.PATTERN -> UiText.StringResource(R.string.auth_error_email_pattern)
+        RegisterError.Email.TOO_LONG -> UiText.StringResource(
+            id = R.string.auth_error_email_too_long,
+            args = arrayOf(ValidateEmailUseCase.EMAIL_MAX_LENGTH)
+        )
+
+        RegisterError.LastName.EMPTY -> UiText.StringResource(R.string.auth_error_last_name_empty)
+        RegisterError.LastName.PATTERN -> UiText.StringResource(R.string.auth_error_last_name_pattern)
+        RegisterError.LastName.TOO_LONG -> UiText.StringResource(
+            id = R.string.auth_error_last_name_too_long,
+            args = arrayOf(ValidateLastNameUseCase.LAST_NAME_MAX_LENGTH)
+        )
+
+        RegisterError.Name.EMPTY -> UiText.StringResource(R.string.auth_error_name_empty)
+        RegisterError.Name.PATTERN -> UiText.StringResource(R.string.auth_error_name_pattern)
+        RegisterError.Name.TOO_LONG -> UiText.StringResource(
+            id = R.string.auth_error_name_too_long,
+            args = arrayOf(ValidateNameUseCase.NAME_MAX_LENGTH)
+        )
+
+        RegisterError.PhoneNumber.EMPTY -> UiText.StringResource(R.string.auth_error_phone_number_empty)
+        RegisterError.PhoneNumber.DIGITS -> UiText.StringResource(R.string.auth_error_phone_number_digits)
+        RegisterError.PhoneNumber.LENGTH -> UiText.StringResource(
+            id = R.string.auth_error_phone_number_length,
+            args = arrayOf(ValidatePhoneNumberUseCase.PHONE_NUMBER_LENGTH)
+        )
+    }
+}

--- a/app/src/main/java/com/pereyrarg11/navigation/auth/presentation/register/RegisterEvent.kt
+++ b/app/src/main/java/com/pereyrarg11/navigation/auth/presentation/register/RegisterEvent.kt
@@ -1,0 +1,5 @@
+package com.pereyrarg11.navigation.auth.presentation.register
+
+sealed interface RegisterEvent {
+    data object RegistrationSuccess : RegisterEvent
+}

--- a/app/src/main/java/com/pereyrarg11/navigation/auth/presentation/register/RegisterScreen.kt
+++ b/app/src/main/java/com/pereyrarg11/navigation/auth/presentation/register/RegisterScreen.kt
@@ -1,0 +1,151 @@
+package com.pereyrarg11.navigation.auth.presentation.register
+
+import android.widget.Toast
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.unit.dp
+import com.pereyrarg11.navigation.R
+import com.pereyrarg11.navigation.core.presentation.designsystem.AppTheme
+import com.pereyrarg11.navigation.core.presentation.designsystem.components.AppButton
+import com.pereyrarg11.navigation.core.presentation.designsystem.components.AppDialog
+import com.pereyrarg11.navigation.core.presentation.designsystem.components.AppTextField
+import com.pereyrarg11.navigation.core.presentation.tools.ObserveAsEvents
+import com.pereyrarg11.navigation.core.presentation.tools.UiText
+import org.koin.androidx.compose.koinViewModel
+
+@Composable
+fun RegisterScreen(
+    onSuccessfulRegistration: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: RegisterViewModel = koinViewModel(),
+) {
+    val context = LocalContext.current
+    val keyboardController = LocalSoftwareKeyboardController.current
+
+    ObserveAsEvents(viewModel.events) { event ->
+        keyboardController?.hide()
+        when (event) {
+            RegisterEvent.RegistrationSuccess -> {
+                Toast.makeText(
+                    context,
+                    R.string.auth_message_registration_success,
+                    Toast.LENGTH_SHORT
+                ).show()
+                onSuccessfulRegistration()
+            }
+        }
+    }
+
+    RegisterScreenContent(
+        state = viewModel.state,
+        onAction = viewModel::onAction,
+        modifier = modifier,
+    )
+}
+
+@Composable
+fun RegisterScreenContent(
+    state: RegisterState,
+    onAction: (RegisterAction) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .background(MaterialTheme.colorScheme.surfaceContainerLowest)
+            .padding(20.dp),
+    ) {
+        AppTextField(
+            state = state.name,
+            label = stringResource(R.string.auth_label_name),
+            modifier = Modifier.fillMaxWidth(),
+            errorMessage = state.nameError?.asString(),
+            imeAction = ImeAction.Next,
+        )
+        Spacer(modifier = Modifier.height(28.dp))
+        AppTextField(
+            state = state.lastName,
+            label = stringResource(R.string.auth_label_last_name),
+            modifier = Modifier.fillMaxWidth(),
+            errorMessage = state.lastNameError?.asString(),
+            imeAction = ImeAction.Next,
+        )
+        Spacer(modifier = Modifier.height(28.dp))
+        AppTextField(
+            state = state.phoneNumber,
+            label = stringResource(R.string.auth_label_phone_number),
+            modifier = Modifier.fillMaxWidth(),
+            errorMessage = state.phoneNumberError?.asString(),
+            keyboardType = KeyboardType.Phone,
+            imeAction = ImeAction.Next,
+        )
+        Spacer(modifier = Modifier.height(28.dp))
+        AppTextField(
+            state = state.email,
+            label = stringResource(R.string.auth_label_email),
+            modifier = Modifier.fillMaxWidth(),
+            errorMessage = state.emailError?.asString(),
+            keyboardType = KeyboardType.Email,
+            imeAction = ImeAction.Done,
+        ) {
+            onAction(RegisterAction.OnClickSubmit)
+        }
+        Spacer(modifier = Modifier.height(36.dp))
+        AppButton(
+            label = stringResource(R.string.auth_action_continue),
+            modifier = Modifier.fillMaxWidth(),
+            isEnabled = !state.isSubmitting,
+        ) {
+            onAction(RegisterAction.OnClickSubmit)
+        }
+    }
+
+    if (state.isBadRequest && state.badRequestMessage != null) {
+        AppDialog(
+            title = stringResource(R.string.core_label_error),
+            description = state.badRequestMessage.asString(),
+            primaryButton = {
+                AppButton(
+                    label = stringResource(R.string.core_action_accept)
+                ) {
+                    onAction(RegisterAction.OnDismissError)
+                }
+            },
+        ) { }
+    }
+}
+
+@Preview
+@PreviewLightDark
+@Composable
+private fun RegisterScreenContentPreview() {
+    AppTheme {
+        RegisterScreenContent(
+            state = RegisterState(
+                name = TextFieldState(initialText = "Gabriel"),
+                lastName = TextFieldState(initialText = "Pereyra_!"),
+                lastNameError = UiText.StaticString("Special characters are not allowed"),
+            ),
+            onAction = {},
+        )
+    }
+}

--- a/app/src/main/java/com/pereyrarg11/navigation/auth/presentation/register/RegisterState.kt
+++ b/app/src/main/java/com/pereyrarg11/navigation/auth/presentation/register/RegisterState.kt
@@ -1,0 +1,22 @@
+package com.pereyrarg11.navigation.auth.presentation.register
+
+import androidx.compose.foundation.text.input.TextFieldState
+import com.pereyrarg11.navigation.core.presentation.tools.UiText
+
+data class RegisterState(
+    val name: TextFieldState = TextFieldState(),
+    val isValidName: Boolean = true,
+    val nameError: UiText? = null,
+    val lastName: TextFieldState = TextFieldState(),
+    val isValidLastName: Boolean = true,
+    val lastNameError: UiText? = null,
+    val email: TextFieldState = TextFieldState(),
+    val isValidEmail: Boolean = true,
+    val emailError: UiText? = null,
+    val phoneNumber: TextFieldState = TextFieldState(),
+    val isValidPhoneNumber: Boolean = true,
+    val phoneNumberError: UiText? = null,
+    val isSubmitting: Boolean = false,
+    val isBadRequest: Boolean = false,
+    val badRequestMessage: UiText? = null,
+)

--- a/app/src/main/java/com/pereyrarg11/navigation/auth/presentation/register/RegisterViewModel.kt
+++ b/app/src/main/java/com/pereyrarg11/navigation/auth/presentation/register/RegisterViewModel.kt
@@ -1,0 +1,103 @@
+package com.pereyrarg11.navigation.auth.presentation.register
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.pereyrarg11.navigation.R
+import com.pereyrarg11.navigation.auth.domain.AuthRepository
+import com.pereyrarg11.navigation.auth.domain.register.ValidateEmailUseCase
+import com.pereyrarg11.navigation.auth.domain.register.ValidateNameUseCase
+import com.pereyrarg11.navigation.auth.domain.register.ValidatePhoneNumberUseCase
+import com.pereyrarg11.navigation.core.domain.util.AppResult
+import com.pereyrarg11.navigation.core.domain.util.DataError
+import com.pereyrarg11.navigation.core.presentation.tools.UiText
+import com.pereyrarg11.navigation.core.presentation.tools.toUiText
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.launch
+
+class RegisterViewModel(
+    private val validateName: ValidateNameUseCase,
+    private val validateLastName: ValidateNameUseCase,
+    private val validatePhoneNumber: ValidatePhoneNumberUseCase,
+    private val validateEmail: ValidateEmailUseCase,
+    private val repository: AuthRepository,
+) : ViewModel() {
+    var state by mutableStateOf(RegisterState())
+        private set
+    private val eventChannel = Channel<RegisterEvent>()
+    val events = eventChannel.receiveAsFlow()
+
+    fun onAction(action: RegisterAction) {
+        when (action) {
+            RegisterAction.OnClickSubmit -> submitForm()
+            RegisterAction.OnDismissError -> dismissError()
+        }
+    }
+
+    private fun dismissError() {
+        state = state.copy(
+            isBadRequest = false,
+            badRequestMessage = null,
+        )
+    }
+
+    private fun submitForm() {
+        validateForm()
+        if (state.isValidName && state.isValidLastName && state.isValidEmail && state.isValidPhoneNumber) {
+            registerUser()
+        }
+    }
+
+    private fun registerUser() {
+        viewModelScope.launch {
+            state = state.copy(
+                isSubmitting = true,
+            )
+            val result = repository.registerUser(
+                name = state.name.text.toString().trim(),
+                lastName = state.lastName.text.toString().trim(),
+                phoneNumber = state.phoneNumber.text.toString().trim(),
+                email = state.email.text.toString().trim(),
+            )
+            state = state.copy(
+                isSubmitting = false,
+            )
+            when (result) {
+                is AppResult.Error -> {
+                    val message = when (result.error) {
+                        DataError.Network.CONFLICT -> UiText.StringResource(R.string.auth_register_error_duplicated)
+                        else -> result.error.toUiText()
+                    }
+                    state = state.copy(
+                        isBadRequest = true,
+                        badRequestMessage = message,
+                    )
+                }
+
+                is AppResult.Success -> {
+                    eventChannel.send(RegisterEvent.RegistrationSuccess)
+                }
+            }
+        }
+    }
+
+    private fun validateForm() {
+        val nameValidation = validateName(state.name.text.toString().trim())
+        val lastNameValidation = validateLastName(state.lastName.text.toString().trim())
+        val phoneNumberValidation = validatePhoneNumber(state.phoneNumber.text.toString().trim())
+        val emailValidation = validateEmail(state.email.text.toString().trim())
+        state = state.copy(
+            isValidName = nameValidation == null,
+            nameError = nameValidation?.toUiText(),
+            isValidLastName = lastNameValidation == null,
+            lastNameError = lastNameValidation?.toUiText(),
+            isValidEmail = emailValidation == null,
+            emailError = emailValidation?.toUiText(),
+            isValidPhoneNumber = phoneNumberValidation == null,
+            phoneNumberError = phoneNumberValidation?.toUiText(),
+        )
+    }
+}

--- a/app/src/main/java/com/pereyrarg11/navigation/core/data/di/CoreDataModule.kt
+++ b/app/src/main/java/com/pereyrarg11/navigation/core/data/di/CoreDataModule.kt
@@ -1,0 +1,10 @@
+package com.pereyrarg11.navigation.core.data.di
+
+import com.pereyrarg11.navigation.core.data.networking.HttpClientFactory
+import org.koin.dsl.module
+
+val coreDataModule = module {
+    single {
+        HttpClientFactory().build()
+    }
+}

--- a/app/src/main/java/com/pereyrarg11/navigation/core/data/networking/HttpClientExt.kt
+++ b/app/src/main/java/com/pereyrarg11/navigation/core/data/networking/HttpClientExt.kt
@@ -1,0 +1,94 @@
+package com.pereyrarg11.navigation.core.data.networking
+
+import com.pereyrarg11.navigation.BuildConfig
+import com.pereyrarg11.navigation.core.domain.util.AppResult
+import com.pereyrarg11.navigation.core.domain.util.DataError
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.delete
+import io.ktor.client.request.get
+import io.ktor.client.request.parameter
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.request.url
+import io.ktor.client.statement.HttpResponse
+import io.ktor.util.network.UnresolvedAddressException
+import kotlinx.coroutines.CancellationException
+import kotlinx.serialization.SerializationException
+
+suspend inline fun <reified Response : Any> HttpClient.get(
+    route: String,
+    queryParameters: Map<String, Any?> = mapOf(),
+): AppResult<Response, DataError.Network> {
+    return safeCall {
+        get {
+            url(constructRoute(route))
+            queryParameters.forEach { (key, value) ->
+                parameter(key, value)
+            }
+        }
+    }
+}
+
+suspend inline fun <reified Response : Any> HttpClient.delete(
+    route: String,
+    queryParameters: Map<String, Any?> = mapOf(),
+): AppResult<Response, DataError.Network> {
+    return safeCall {
+        delete {
+            url(constructRoute(route))
+            queryParameters.forEach { (key, value) ->
+                parameter(key, value)
+            }
+        }
+    }
+}
+
+suspend inline fun <reified Request, reified Response : Any> HttpClient.post(
+    route: String,
+    body: Request,
+): AppResult<Response, DataError.Network> {
+    return safeCall {
+        post {
+            url(constructRoute(route))
+            setBody(body)
+        }
+    }
+}
+
+suspend inline fun <reified T> safeCall(performRequest: () -> HttpResponse): AppResult<T, DataError.Network> {
+    // TODO: log error message to Crashlytics
+    val response = try {
+        performRequest()
+    } catch (e: UnresolvedAddressException) {
+        e.printStackTrace()
+        return AppResult.Error(DataError.Network.NO_INTERNET)
+    } catch (e: SerializationException) {
+        e.printStackTrace()
+        return AppResult.Error(DataError.Network.SERIALIZATION)
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        e.printStackTrace()
+        return AppResult.Error(DataError.Network.UNKNOWN)
+    }
+
+    return responseToAppResult(response)
+}
+
+suspend inline fun <reified T> responseToAppResult(response: HttpResponse): AppResult<T, DataError.Network> {
+    return when (response.status.value) {
+        in 200..299 -> AppResult.Success(response.body<T>())
+        400 -> AppResult.Success(response.body<T>()) // both error code and message are in DTO
+        401 -> AppResult.Error(DataError.Network.UNAUTHORIZED)
+        in 500..599 -> AppResult.Error(DataError.Network.SERVER_ERROR)
+        else -> AppResult.Error(DataError.Network.UNKNOWN)
+    }
+}
+
+fun constructRoute(route: String): String {
+    return when {
+        route.contains(BuildConfig.AUTH_URL) -> route
+        route.startsWith("/") -> BuildConfig.AUTH_URL + route
+        else -> BuildConfig.AUTH_URL + "/$route"
+    }
+}

--- a/app/src/main/java/com/pereyrarg11/navigation/core/data/networking/HttpClientFactory.kt
+++ b/app/src/main/java/com/pereyrarg11/navigation/core/data/networking/HttpClientFactory.kt
@@ -1,0 +1,44 @@
+package com.pereyrarg11.navigation.core.data.networking
+
+import android.util.Log
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.defaultRequest
+import io.ktor.client.plugins.logging.LogLevel
+import io.ktor.client.plugins.logging.Logger
+import io.ktor.client.plugins.logging.Logging
+import io.ktor.client.request.header
+import io.ktor.http.ContentType
+import io.ktor.http.contentType
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.serialization.json.Json
+
+class HttpClientFactory {
+    fun build(): HttpClient {
+        return HttpClient(CIO) {
+            install(ContentNegotiation) {
+                json(
+                    json = Json {
+                        ignoreUnknownKeys = true
+                    }
+                )
+            }
+            install(Logging) {
+                logger = object : Logger {
+                    override fun log(message: String) {
+                        // TODO: inject logger here
+                        Log.d("HttpClientFactory", message)
+                    }
+                }
+                level = LogLevel.ALL
+            }
+            // TODO: add basic auth by using https://ktor.io/docs/client-basic-auth.html#configure
+            defaultRequest {
+                contentType(ContentType.Application.Json)
+                // TODO: get secrets and use them here
+                header("x-api-key", "your_api_key")
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/pereyrarg11/navigation/core/domain/util/AppError.kt
+++ b/app/src/main/java/com/pereyrarg11/navigation/core/domain/util/AppError.kt
@@ -1,0 +1,3 @@
+package com.pereyrarg11.navigation.core.domain.util
+
+interface AppError

--- a/app/src/main/java/com/pereyrarg11/navigation/core/domain/util/AppResult.kt
+++ b/app/src/main/java/com/pereyrarg11/navigation/core/domain/util/AppResult.kt
@@ -1,0 +1,19 @@
+package com.pereyrarg11.navigation.core.domain.util
+
+sealed interface AppResult<out D, out E : AppError> {
+    data class Success<out D>(val data: D) : AppResult<D, Nothing>
+    data class Error<out E : AppError>(val error: E) : AppResult<Nothing, E>
+}
+
+inline fun <T, E : AppError, R> AppResult<T, E>.map(mapper: (T) -> R): AppResult<R, E> {
+    return when (this) {
+        is AppResult.Error -> AppResult.Error(error)
+        is AppResult.Success -> AppResult.Success(mapper(data))
+    }
+}
+
+typealias EmptyAppResult<E> = AppResult<Unit, E>
+
+fun <T, E : AppError> AppResult<T, E>.asEmptyAppResult(): EmptyAppResult<E> {
+    return map { }
+}

--- a/app/src/main/java/com/pereyrarg11/navigation/core/domain/util/DataError.kt
+++ b/app/src/main/java/com/pereyrarg11/navigation/core/domain/util/DataError.kt
@@ -1,0 +1,17 @@
+package com.pereyrarg11.navigation.core.domain.util
+
+sealed interface DataError : AppError {
+
+    enum class Network : DataError {
+        UNAUTHORIZED,
+        CONFLICT,
+        NO_INTERNET,
+        SERVER_ERROR,
+        SERIALIZATION,
+        UNKNOWN,
+    }
+
+    enum class Local : DataError {
+        DISK_FULL,
+    }
+}

--- a/app/src/main/java/com/pereyrarg11/navigation/core/presentation/designsystem/components/AppButton.kt
+++ b/app/src/main/java/com/pereyrarg11/navigation/core/presentation/designsystem/components/AppButton.kt
@@ -12,14 +12,13 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.pereyrarg11.navigation.core.presentation.designsystem.AppTheme
-import com.pereyrarg11.navigation.core.presentation.tools.UiText
 
 @Composable
 fun AppButton(
-    label: UiText,
-    onClick: () -> Unit,
+    label: String,
     modifier: Modifier = Modifier,
     isEnabled: Boolean = true,
+    onClick: () -> Unit,
 ) {
     Button(
         onClick = onClick,
@@ -32,7 +31,7 @@ fun AppButton(
         enabled = isEnabled,
     ) {
         Text(
-            text = label.asString(),
+            text = label,
             style = MaterialTheme.typography.titleSmall,
         )
     }
@@ -44,7 +43,7 @@ fun AppButton(
 private fun AppButtonPreview() {
     AppTheme {
         AppButton(
-            label = UiText.StaticString("Click Me"),
+            label = "Click Me",
             onClick = {},
         )
     }

--- a/app/src/main/java/com/pereyrarg11/navigation/core/presentation/designsystem/components/AppDialog.kt
+++ b/app/src/main/java/com/pereyrarg11/navigation/core/presentation/designsystem/components/AppDialog.kt
@@ -1,0 +1,95 @@
+package com.pereyrarg11.navigation.core.presentation.designsystem.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Dialog
+import com.pereyrarg11.navigation.core.presentation.designsystem.AppTheme
+
+@Composable
+fun AppDialog(
+    title: String,
+    description: String,
+    primaryButton: @Composable RowScope.() -> Unit,
+    modifier: Modifier = Modifier,
+    secondaryButton: @Composable RowScope.() -> Unit = {},
+    onDismiss: () -> Unit,
+) {
+    Dialog(onDismissRequest = onDismiss) {
+        Column(
+            modifier = modifier
+                .clip(RoundedCornerShape(15.dp))
+                .background(MaterialTheme.colorScheme.surface)
+                .padding(15.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Text(
+                text = title,
+                fontWeight = FontWeight.SemiBold,
+                textAlign = TextAlign.Center,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            Text(
+                text = description,
+                fontSize = 12.sp,
+                textAlign = TextAlign.Center,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(
+                    space = 16.dp,
+                    alignment = Alignment.End
+                ),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                secondaryButton()
+                primaryButton()
+            }
+        }
+    }
+}
+
+@Preview
+@PreviewLightDark
+@Composable
+private fun AppDialogPreview() {
+    AppTheme {
+        Surface {
+            AppDialog(
+                title = "Title",
+                description = "Description",
+                primaryButton = {
+                    AppButton(
+                        label = "Primary",
+                    ) { }
+                },
+                secondaryButton = {
+                    AppButton(
+                        label = "Secondary",
+                    ) { }
+                }
+            ) { }
+        }
+    }
+}

--- a/app/src/main/java/com/pereyrarg11/navigation/core/presentation/designsystem/components/AppLink.kt
+++ b/app/src/main/java/com/pereyrarg11/navigation/core/presentation/designsystem/components/AppLink.kt
@@ -9,16 +9,15 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import com.pereyrarg11.navigation.core.presentation.designsystem.AppTheme
-import com.pereyrarg11.navigation.core.presentation.tools.UiText
 
 @Composable
 fun AppLink(
-    label: UiText,
+    label: String,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Text(
-        text = label.asString(),
+        text = label,
         modifier = modifier
             .clickable(onClick = onClick),
         style = MaterialTheme.typography.titleSmall,
@@ -33,7 +32,7 @@ fun AppLink(
 private fun AppLinkPreview() {
     AppTheme {
         AppLink(
-            label = UiText.StaticString("Click Me"),
+            label = "Click Me",
             onClick = {},
         )
     }

--- a/app/src/main/java/com/pereyrarg11/navigation/core/presentation/designsystem/components/AppTextField.kt
+++ b/app/src/main/java/com/pereyrarg11/navigation/core/presentation/designsystem/components/AppTextField.kt
@@ -1,6 +1,5 @@
 package com.pereyrarg11.navigation.core.presentation.designsystem.components
 
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Column
@@ -9,10 +8,10 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.foundation.text2.BasicTextField2
-import androidx.compose.foundation.text2.input.TextFieldLineLimits
-import androidx.compose.foundation.text2.input.TextFieldState
+import androidx.compose.foundation.text.input.TextFieldLineLimits
+import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -26,6 +25,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewLightDark
@@ -33,33 +33,33 @@ import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.dp
 import com.pereyrarg11.navigation.core.presentation.designsystem.AppTheme
-import com.pereyrarg11.navigation.core.presentation.tools.UiText
 
-@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun AppTextField(
     state: TextFieldState,
-    label: UiText,
+    label: String,
     modifier: Modifier = Modifier,
-    errorMessage: UiText? = null,
+    errorMessage: String? = null,
     keyboardType: KeyboardType = KeyboardType.Text,
+    imeAction: ImeAction = ImeAction.Unspecified,
+    onKeyboardAction: () -> Unit = {},
 ) {
     var isFocused by remember {
         mutableStateOf(false)
     }
     val inputShape = RoundedCornerShape(8.dp)
-    val errorMessageStr = errorMessage?.asString().orEmpty()
+    val errorMessageStr = errorMessage.orEmpty()
 
     Column(
         modifier = modifier,
     ) {
         Text(
-            text = label.asString(),
+            text = label,
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurface,
         )
         Spacer(modifier = Modifier.height(6.dp))
-        BasicTextField2(
+        BasicTextField(
             state = state,
             modifier = Modifier
                 .fillMaxWidth()
@@ -90,14 +90,19 @@ fun AppTextField(
             ),
             keyboardOptions = KeyboardOptions(
                 keyboardType = keyboardType,
+                imeAction = imeAction,
             ),
+            onKeyboardAction = { defaultAction ->
+                defaultAction()
+                onKeyboardAction()
+            },
             lineLimits = TextFieldLineLimits.SingleLine,
             cursorBrush = SolidColor(MaterialTheme.colorScheme.primary)
         )
         if (errorMessage != null) {
             Spacer(modifier = Modifier.height(6.dp))
             Text(
-                text = errorMessage.asString(),
+                text = errorMessage,
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.error,
             )
@@ -105,26 +110,25 @@ fun AppTextField(
     }
 }
 
-class AppTextFieldErrorMessageProvider : PreviewParameterProvider<UiText?> {
-    override val values: Sequence<UiText?>
+class AppTextFieldErrorMessageProvider : PreviewParameterProvider<String?> {
+    override val values: Sequence<String?>
         get() = sequenceOf(
             null,
-            UiText.StaticString("Error message")
+            "Error message"
         )
 }
 
-@OptIn(ExperimentalFoundationApi::class)
 @Preview
 @PreviewLightDark
 @Composable
 private fun AppTextFieldPreview(
-    @PreviewParameter(AppTextFieldErrorMessageProvider::class) errorMessage: UiText?,
+    @PreviewParameter(AppTextFieldErrorMessageProvider::class) errorMessage: String?,
 ) {
     AppTheme {
         Surface {
             AppTextField(
                 state = TextFieldState(initialText = "Text"),
-                label = UiText.StaticString("Label"),
+                label = "Label",
                 errorMessage = errorMessage,
             )
         }

--- a/app/src/main/java/com/pereyrarg11/navigation/core/presentation/tools/DataErrorExt.kt
+++ b/app/src/main/java/com/pereyrarg11/navigation/core/presentation/tools/DataErrorExt.kt
@@ -1,0 +1,12 @@
+package com.pereyrarg11.navigation.core.presentation.tools
+
+import com.pereyrarg11.navigation.R
+import com.pereyrarg11.navigation.core.domain.util.DataError
+
+fun DataError.toUiText(): UiText {
+    return when(this) {
+        DataError.Local.DISK_FULL -> UiText.StringResource(R.string.core_error_disk_full)
+        DataError.Network.NO_INTERNET -> UiText.StringResource(R.string.core_error_no_internet)
+        else -> UiText.StringResource(R.string.core_error_unknown)
+    }
+}

--- a/app/src/main/java/com/pereyrarg11/navigation/core/presentation/tools/ObserveAsEvents.kt
+++ b/app/src/main/java/com/pereyrarg11/navigation/core/presentation/tools/ObserveAsEvents.kt
@@ -1,0 +1,27 @@
+package com.pereyrarg11.navigation.core.presentation.tools
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.repeatOnLifecycle
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.withContext
+
+@Composable
+fun <T> ObserveAsEvents(
+    flow: Flow<T>,
+    key1: Any? = null,
+    key2: Any? = null,
+    onEvent: (T) -> Unit,
+) {
+    val lifecycleOwner = LocalLifecycleOwner.current
+    LaunchedEffect(flow, lifecycleOwner.lifecycle, key1, key2) {
+        lifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+            withContext(Dispatchers.Main.immediate) {
+                flow.collect(onEvent)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/pereyrarg11/navigation/di/AppModule.kt
+++ b/app/src/main/java/com/pereyrarg11/navigation/di/AppModule.kt
@@ -1,0 +1,6 @@
+package com.pereyrarg11.navigation.di
+
+import org.koin.dsl.module
+
+val appModule = module {
+}

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -6,4 +6,23 @@
     <string name="auth_label_phone_number">Número telefónico</string>
     <string name="auth_label_email">Correo electrónico</string>
     <string name="auth_action_continue">Continuar</string>
+    <string name="auth_error_email_empty">Escribe tu correo electrónico.</string>
+    <string name="auth_error_email_pattern">Escribe un correo electrónico con formato válido.</string>
+    <string name="auth_error_email_too_long">No debe ser mayor a $1%d caracteres.</string>
+    <string name="auth_error_last_name_empty">Escribe tu apellido</string>
+    <string name="auth_error_last_name_pattern">No se permiten caracteres especiales.</string>
+    <string name="auth_error_last_name_too_long">No debe ser mayor a %1$d caracteres.</string>
+    <string name="auth_error_name_empty">Escribe tu nombre.</string>
+    <string name="auth_error_name_pattern">No se permiten caracteres especiales.</string>
+    <string name="auth_error_name_too_long">No debe ser mayor a $1%d caracteres.</string>
+    <string name="auth_error_phone_number_empty">Escribe tu número telefónico.</string>
+    <string name="auth_error_phone_number_length">Debe tener %1$d dígitos.</string>
+    <string name="auth_error_phone_number_digits">Solo dígitos, sin espacios.</string>
+    <string name="core_error_unknown">Ocurrió un error. Intente más tarde.</string>
+    <string name="auth_message_registration_success">¡Registro exitoso!</string>
+    <string name="core_error_no_internet">No hay conexión a Internet.</string>
+    <string name="core_error_disk_full">No hay espacio en el dispositivo.</string>
+    <string name="auth_register_error_duplicated">Ya hay otro usuario con el mismo correo electrónico o número telefónico.</string>
+    <string name="core_label_error">Error</string>
+    <string name="core_action_accept">Aceptar</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,4 +5,23 @@
     <string name="auth_label_phone_number">Phone number</string>
     <string name="auth_label_email">Email</string>
     <string name="auth_action_continue">Continue</string>
+    <string name="auth_error_email_empty">Write your email.</string>
+    <string name="auth_error_email_pattern">Write an email with a valid format.</string>
+    <string name="auth_error_email_too_long">It must not be longer than $1%d characters.</string>
+    <string name="auth_error_last_name_empty">Type your last name.</string>
+    <string name="auth_error_last_name_pattern">Special characters are not allowed.</string>
+    <string name="auth_error_last_name_too_long">No longer than %1$d characters.</string>
+    <string name="auth_error_name_empty">Type your name.</string>
+    <string name="auth_error_name_pattern">Special characters are not allowed.</string>
+    <string name="auth_error_name_too_long">No longer than $1%d characters.</string>
+    <string name="auth_error_phone_number_empty">Type your phone number.</string>
+    <string name="auth_error_phone_number_length">Must have %1$d digits.</string>
+    <string name="auth_error_phone_number_digits">Only digits, no spaces.</string>
+    <string name="core_error_unknown">There was an error. Please try later.</string>
+    <string name="auth_message_registration_success">Register was successful!</string>
+    <string name="core_error_no_internet">There is not Internet connection.</string>
+    <string name="core_error_disk_full">There is no more space on the device.</string>
+    <string name="auth_register_error_duplicated">There is another user with the same phone number or email.</string>
+    <string name="core_label_error">Error</string>
+    <string name="core_action_accept">Accept</string>
 </resources>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,4 +3,5 @@ plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.compose) apply false
+    alias(libs.plugins.kotlin.serialization) apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,10 @@ junitVersion = "1.2.1"
 espressoCore = "3.6.1"
 lifecycleRuntimeKtx = "2.9.1"
 activityCompose = "1.10.1"
-composeBom = "2024.04.01"
+composeBom = "2025.07.00"
+koin = "4.0.3"
+ktor = "3.2.2"
+ktorClientLogging = "3.2.2"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -24,9 +27,18 @@ androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-toolin
 androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
+koin-androidx-compose = { module = "io.insert-koin:koin-androidx-compose", version.ref = "koin" }
+koin-androidx-compose-navigation = { module = "io.insert-koin:koin-androidx-compose-navigation", version.ref = "koin" }
+ktor-client-auth = { module = "io.ktor:ktor-client-auth", version.ref = "ktor" }
+ktor-client-cio = { module = "io.ktor:ktor-client-cio", version.ref = "ktor" }
+ktor-client-content-negotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor" }
+ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
+ktor-client-logging = { module = "io.ktor:ktor-client-logging", version.ref = "ktorClientLogging" }
+ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 


### PR DESCRIPTION
### Description

Add Register screen in Auth module

### Context

This screen is needed to let users create its own account itself.

### Changes

- add `RegisterScreen`
- add stuff related to Http client in `core`
- implement Dependency Injection with Koin
- add `AppDialog` component
- add github files (codeowners, PR template)

### Type of Changes

Check with an 'x' the type of changes made:

- [x] New Feature
- [ ] Bug Fix
- [ ] Dependency upgrade
- [ ] Refactor
- [ ] Performance Improvement
- [ ] Style Changes (formatting, spacing, etc.)
- [ ] Documentation
- [ ] Other (specify)

### Code Quality Checks

- [x] All app-flavors and build-variants have been built successfully.
- [x] Coding style of the project has been followed.
- [ ] Documentation has been updated, if necessary.

### Screenshots
<img width="540" height="1080" alt="register_screen" src="https://github.com/user-attachments/assets/93cc7e18-6423-42ee-9ffd-abf5125b32e7" />
